### PR TITLE
Added functionality to prioritize Quests

### DIFF
--- a/src/main/java/com/darrenswhite/rs/ironquest/gui/MainPane.java
+++ b/src/main/java/com/darrenswhite/rs/ironquest/gui/MainPane.java
@@ -4,6 +4,8 @@ import com.darrenswhite.rs.ironquest.IronQuest;
 import com.darrenswhite.rs.ironquest.action.Action;
 import com.darrenswhite.rs.ironquest.player.Player;
 import com.darrenswhite.rs.ironquest.player.Skill;
+import com.darrenswhite.rs.ironquest.quest.Quest.UserPriority;
+import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import javafx.application.Platform;
@@ -11,7 +13,10 @@ import javafx.beans.binding.Bindings;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.geometry.Insets;
+import javafx.scene.control.Alert;
+import javafx.scene.control.Alert.AlertType;
 import javafx.scene.control.Button;
+import javafx.scene.control.ButtonType;
 import javafx.scene.control.ComboBox;
 import javafx.scene.control.ListView;
 import javafx.scene.control.SelectionMode;
@@ -92,6 +97,11 @@ public class MainPane extends GridPane {
    * Search text for finding quest position
    */
   private TextField txtSearch;
+
+  /**
+   * Resets all user-set quest priorities to NORMAL
+   */
+  private Button btnResetQuestPriorities;
 
   private void actionClick(MouseEvent e) {
     // Get selected Action
@@ -231,6 +241,27 @@ public class MainPane extends GridPane {
     btnRun.setMaxWidth(Double.MAX_VALUE);
     HBox.setHgrow(btnRun, Priority.ALWAYS);
 
+    btnResetQuestPriorities = new Button("Reset Custom Priorities");
+    btnResetQuestPriorities
+        .setTooltip(new Tooltip(("Resets all user-set quest priorities to NORMAL")));
+
+    btnResetQuestPriorities.setOnAction(e -> {
+
+      Alert alert = new Alert(AlertType.CONFIRMATION);
+      alert.setTitle("Confirmation Dialog");
+      alert.setHeaderText("This button will reset all custom quest priorities to NORMAL");
+      alert.setContentText("Are you sure you want to reset ALL priorities?");
+
+      Optional<ButtonType> result = alert.showAndWait();
+      if (result.isPresent() && result.get() == ButtonType.OK) {
+        resetQuestPriorities();
+      }
+    });
+
+    btnResetQuestPriorities.setMaxHeight(Double.MAX_VALUE);
+    btnResetQuestPriorities.setMaxWidth(Double.MAX_VALUE);
+    HBox.setHgrow(btnResetQuestPriorities, Priority.ALWAYS);
+
     // Max columns
     int columns = 10;
 
@@ -238,11 +269,13 @@ public class MainPane extends GridPane {
     add(txtRSN, 0, 0, (int) (columns * 0.4), 1);
     add(txtSearch, 0, 1, (int) (columns * 0.4), 1);
 
-    add(btnIronman, (int) (columns * 0.4), 0, (int) (columns * 0.3), 1);
+    add(btnIronman, (int) (columns * 0.4), 0, (int) (columns * 0.2), 1);
     add(btnRecommended, (int) (columns * 0.4), 1, (int) (columns * 0.3), 1);
 
-    add(btnLampSkills, (int) (columns * 0.7), 0, (int) (columns * 0.3), 1);
+    add(btnLampSkills, (int) (columns * 0.6), 0, (int) (columns * 0.2), 1);
     add(cmbMembers, (int) (columns * 0.7), 1, (int) (columns * 0.3), 1);
+
+    add(btnResetQuestPriorities, (int) (columns * 0.8), 0, (int) (columns * 0.2), 1);
 
     add(lstActions, 0, 2, (int) (columns * 0.5), 1);
     add(lstInfo, (int) (columns * 0.5), 2, (int) (columns * 0.5), 1);
@@ -250,7 +283,9 @@ public class MainPane extends GridPane {
     add(btnRun, 0, 3, columns, 1);
 
     // Resize columns evenly
-    for (int i = 0; i < columns; i++) {
+    for (
+        int i = 0;
+        i < columns; i++) {
       ColumnConstraints cc = new ColumnConstraints();
 
       cc.setPercentWidth(100.0 / columns);
@@ -343,6 +378,11 @@ public class MainPane extends GridPane {
         break;
       }
     }
+  }
+
+  private void resetQuestPriorities() {
+    IronQuest quest = IronQuest.getInstance();
+    quest.getQuests().forEach(q -> q.setUserPriority(UserPriority.NORMAL));
   }
 
   private void setMembersFree() {

--- a/src/main/java/com/darrenswhite/rs/ironquest/gui/QuestDetail.java
+++ b/src/main/java/com/darrenswhite/rs/ironquest/gui/QuestDetail.java
@@ -2,6 +2,7 @@ package com.darrenswhite.rs.ironquest.gui;
 
 import com.darrenswhite.rs.ironquest.player.Skill;
 import com.darrenswhite.rs.ironquest.quest.Quest;
+import com.darrenswhite.rs.ironquest.quest.Quest.UserPriority;
 import com.darrenswhite.rs.ironquest.quest.requirement.QuestRequirement;
 import com.darrenswhite.rs.ironquest.quest.requirement.Requirement;
 import com.darrenswhite.rs.ironquest.quest.requirement.SkillRequirement;
@@ -14,12 +15,15 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
+import javafx.collections.FXCollections;
 import javafx.geometry.HPos;
 import javafx.geometry.Insets;
 import javafx.geometry.VPos;
 import javafx.scene.Scene;
+import javafx.scene.control.ComboBox;
 import javafx.scene.control.Label;
 import javafx.scene.control.ScrollPane;
+import javafx.scene.control.Tooltip;
 import javafx.scene.input.MouseEvent;
 import javafx.scene.layout.GridPane;
 import javafx.scene.text.Font;
@@ -143,6 +147,16 @@ public class QuestDetail extends Stage {
   private Label lstLampRewards;
 
   /**
+   * The user priority label
+   */
+  private Label lblUserPriority;
+
+  /**
+   * The user priority dropdown box
+   */
+  private ComboBox<Quest.UserPriority> cmbPriority;
+
+  /**
    * Creates a new QuestDetail Stage
    *
    * @param owner The parent Window
@@ -243,6 +257,15 @@ public class QuestDetail extends Stage {
     lblQuestPointsValue = new Label(Integer.toString(quest.getQuestPoints()));
 
     lblSkillRewards = new Label("Skill rewards");
+
+    lblUserPriority = new Label("User priority");
+
+    cmbPriority = new ComboBox<>(FXCollections.observableArrayList(UserPriority.values()));
+    cmbPriority.setTooltip(new Tooltip("Set custom priority for quest"));
+
+    cmbPriority.setOnAction(e -> setQuestUserPriority(quest));
+
+    cmbPriority.getSelectionModel().select(quest.getUserPriority());
     // Align to the top
     GridPane.setValignment(lblSkillRewards, VPos.TOP);
 
@@ -296,20 +319,22 @@ public class QuestDetail extends Stage {
 
     // Add components to the grid
     grid.add(lblName, 0, 0, 2, 1);
-    grid.add(lblMembers, 0, 1);
-    grid.add(lblMembersValue, 1, 1);
-    grid.add(lblSkillReqs, 0, 2);
-    grid.add(lstSkillReqs, 1, 2);
-    grid.add(lblQuestReqs, 0, 3);
-    grid.add(lstQuestReqs, 1, 3);
-    grid.add(lblOtherReqs, 0, 4);
-    grid.add(lstOtherReqs, 1, 4);
-    grid.add(lblQuestPoints, 0, 5);
-    grid.add(lblQuestPointsValue, 1, 5);
-    grid.add(lblSkillRewards, 0, 6);
-    grid.add(lstSkillRewards, 1, 6);
-    grid.add(lblLampRewards, 0, 7);
-    grid.add(lstLampRewards, 1, 7);
+    grid.add(lblUserPriority, 0, 1);
+    grid.add(cmbPriority, 1, 1);
+    grid.add(lblMembers, 0, 2);
+    grid.add(lblMembersValue, 1, 2);
+    grid.add(lblSkillReqs, 0, 3);
+    grid.add(lstSkillReqs, 1, 3);
+    grid.add(lblQuestReqs, 0, 4);
+    grid.add(lstQuestReqs, 1, 4);
+    grid.add(lblOtherReqs, 0, 5);
+    grid.add(lstOtherReqs, 1, 5);
+    grid.add(lblQuestPoints, 0, 6);
+    grid.add(lblQuestPointsValue, 1, 6);
+    grid.add(lblSkillRewards, 0, 7);
+    grid.add(lstSkillRewards, 1, 7);
+    grid.add(lblLampRewards, 0, 8);
+    grid.add(lstLampRewards, 1, 8);
 
     // Set the scene
     sizeToScene();
@@ -355,5 +380,12 @@ public class QuestDetail extends Stage {
       questDetail.sizeToScene();
       questDetail.showAndWait();
     }
+  }
+
+  private void setQuestUserPriority(Quest quest) {
+
+    Quest.UserPriority newPriority  = cmbPriority.getSelectionModel().getSelectedItem();
+    quest.setUserPriority(newPriority);
+
   }
 }

--- a/src/main/java/com/darrenswhite/rs/ironquest/gui/QuestDetail.java
+++ b/src/main/java/com/darrenswhite/rs/ironquest/gui/QuestDetail.java
@@ -382,6 +382,11 @@ public class QuestDetail extends Stage {
     }
   }
 
+  /**
+   * Sets the UserPriority of a quest
+   *
+   * @param quest The quest to change
+   */
   private void setQuestUserPriority(Quest quest) {
 
     Quest.UserPriority newPriority  = cmbPriority.getSelectionModel().getSelectedItem();

--- a/src/main/java/com/darrenswhite/rs/ironquest/quest/Quest.java
+++ b/src/main/java/com/darrenswhite/rs/ironquest/quest/Quest.java
@@ -64,6 +64,11 @@ public class Quest {
   private Set<Set<Skill>> previousLampSkills = new HashSet<>();
 
   /**
+   * Quest completion priority
+   */
+  private UserPriority userPriority;
+
+  /**
    * Creates a new Quest instance
    *
    * @param id The Quest unique id
@@ -86,6 +91,7 @@ public class Quest {
     this.questPoints = questPoints;
     this.skillRewards = Objects.requireNonNull(skillRewards);
     this.lampRewards = Objects.requireNonNull(lampRewards);
+    this.userPriority = UserPriority.NORMAL;
   }
 
   /**
@@ -146,6 +152,15 @@ public class Quest {
    * @return The priority of this Quest
    */
   public int getPriority(Player p, boolean ironman, boolean recommended) {
+
+    if (userPriority == UserPriority.LOW) {
+      return Integer.MIN_VALUE;
+    }
+
+    if (userPriority == UserPriority.HIGH) {
+      return Integer.MAX_VALUE;
+    }
+
     // Get the total remaining skill requirements
     int reqs = getRemainingSkillRequirements(p, ironman, recommended).stream()
         .mapToInt(SkillRequirement::getLevel).sum();
@@ -260,6 +275,24 @@ public class Quest {
   }
 
   /**
+   * Gets the quest's completion priority
+   *
+   * @return The quest's completion priority
+   */
+  public UserPriority getUserPriority() {
+    return userPriority;
+  }
+
+  /**
+   * Sets the quest's completion priority
+   *
+   * @param userPriority The priority level
+   */
+  public void setUserPriority(UserPriority userPriority) {
+    this.userPriority = userPriority;
+  }
+
+  /**
    * Checks if the Player meets all 'other' requirements
    *
    * @param p The Player instance
@@ -326,5 +359,11 @@ public class Quest {
         ", skillRewards=" + skillRewards +
         ", lampRewards=" + lampRewards +
         '}';
+  }
+
+  public enum UserPriority {
+    HIGH,
+    NORMAL,
+    LOW
   }
 }

--- a/src/main/java/com/darrenswhite/rs/ironquest/quest/Quest.java
+++ b/src/main/java/com/darrenswhite/rs/ironquest/quest/Quest.java
@@ -190,6 +190,24 @@ public class Quest {
   }
 
   /**
+   * Gets the remaining Quests to complete for this quest
+   *
+   * @param player The player to check for
+   * @return The remaining Quests
+   */
+  public Set<Quest> getRemainingQuestRequirements(Player player) {
+    IronQuest ironQuest = IronQuest.getInstance();
+
+    // Given the Quest IDs for the Quest Requirements,
+    // filter out completed quests and then return a Set
+    // of Quest objects mapped from the Quest ID
+    return getQuestRequirements().stream()
+        .filter(q -> !player.isQuestCompleted(q.getId()))
+        .map(q -> ironQuest.getQuest(q.getId()))
+        .collect(Collectors.toSet());
+  }
+
+  /**
    * Gets the remaining skill level requirements for this Quest
    *
    * @param p The Player instance
@@ -362,6 +380,7 @@ public class Quest {
   }
 
   public enum UserPriority {
+    MAX,
     HIGH,
     NORMAL,
     LOW


### PR DESCRIPTION
The user can set 4 priorities for a Quest:

- MAX: Calculates the quickest path to complete the quest
- HIGH: Sets the priority to Integer.MAX_VALUE when calculating priority
- NORMAL (Default): No change from current algorithm
- LOW: Sets priority to Integer.MIN_VALUE when calculating priority

The User can set the priority through the 'Quest Details' panel. The User can reset all priorities to NORMAL through a button click on the Main Panel. Quest priorities are saved and loaded from the current properties file.